### PR TITLE
Column not nullable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,4 +106,4 @@ DEPENDENCIES
   zero_downtime_migrations!
 
 BUNDLED WITH
-   1.12.5
+   1.16.0

--- a/lib/zero_downtime_migrations/validation/add_column.rb
+++ b/lib/zero_downtime_migrations/validation/add_column.rb
@@ -2,13 +2,13 @@ module ZeroDowntimeMigrations
   class Validation
     class AddColumn < Validation
       def validate!
-        return if options[:default].nil? # only nil is safe
-        error!(message)
+        error!(not_null_message) if options[:null] == false
+        error!(default_present_message) if options.key?(:default) && !options[:default].nil? # only nil is safe
       end
 
       private
 
-      def message
+      def default_present_message
         <<-MESSAGE.strip_heredoc
           Adding a column with a default is unsafe!
 
@@ -43,7 +43,7 @@ module ZeroDowntimeMigrations
             class BackportDefault#{column_title}To#{table_title} < ActiveRecord::Migration
               def change
                 #{table_model}.select(:id).find_in_batches.with_index do |records, index|
-                  puts "Processing batch \#{index + 1}\\r"
+                  Rails.logger.info "Processing batch \#{index + 1} for #{column_title} in #{table_title}"
                   #{table_model}.where(id: records).update_all(#{column}: #{column_default})
                 end
               end
@@ -65,6 +65,101 @@ module ZeroDowntimeMigrations
                 safety_assured { add_column :#{table}, :#{column}, :#{column_type}, default: #{column_default} }
               end
             end
+        MESSAGE
+      end
+
+      def not_null_message
+        <<-MESSAGE.strip_heredoc
+          Adding a not nullable column is unsafe!
+
+          This can take a long time with significant database
+          size or traffic and lock your table!
+
+          When we add a column with the not nullable option it has to
+          lock the table while it performs an UPDATE for ALL rows to
+          set a default.
+
+          Adding a not nullable column is onerous, but if it's really
+          really necessary there are two pathways depending on the size
+          of the table:
+
+          Small tables (< 500 000 rows)
+
+          First let’s add the column without a default.
+
+            class Add#{column_title}To#{table_title} < ActiveRecord::Migration
+              def change
+                add_column :#{table}, :#{column}, :#{column_type}
+              end
+            end
+
+          Then we’ll set the new column default in a separate migration.
+          Note that this does not update any existing data. This only
+          sets the default for newly inserted rows going forward.
+
+            class AddDefault#{column_title}To#{table_title} < ActiveRecord::Migration
+              def change
+                change_column_default :#{table}, :#{column}, #{column_default}
+              end
+            end
+
+          Then we’ll backport the default value for existing data in
+          batches. This should be done in its own migration as well.
+          Updating in batches allows us to lock 1000 rows at a time
+          (or whatever batch size we prefer).
+
+            class BackportDefault#{column_title}To#{table_title} < ActiveRecord::Migration
+              def change
+                #{table_model}.select(:id).find_in_batches.with_index do |records, index|
+                  Rails.logger.info "Processing batch \#{index + 1} for #{column_title} in #{table_title}"
+                  #{table_model}.where(id: records).update_all(#{column}: #{column_default})
+                end
+              end
+            end
+
+          Finally add the not null constraint on the table - note this
+          still requires a full table scan to check all values
+
+            class Change#{column_title}ToNotNullable < ActiveRecord::Migration
+              def change
+                change_column_null :#{table}, :#{column}, false
+              end
+            end
+
+          Larger tables (> 500 000 rows)
+
+          Firstly, create a new table with the addition of the non-nullable
+          column and adjust the code to write to both tables.
+
+            class AddNew#{table}WithNotNullable#{column_title} < ActiveRecord::Migration
+              def change
+                create_table :#{table}_new do |t|
+                  t.#{column_type}, default: #{column_default}, null: false
+                  ....
+                end
+              end
+            end
+
+          Then backport the expected value for existing data in batches.
+          This should be done in its own rake task as well.
+
+            #{table_model}New.select(:id).find_in_batches.with_index do |records, index|
+              Rails.logger.info "Processing batch \#{index + 1} for #{column_title} in #{table_title}New"
+              #{table_model}New.where(id: records).update_all(#{column}: #{column_default})
+            end
+
+          Finally, in a seperate PR switch the code to use the new table
+          and follow it up with yet another PR to drop the old table.
+
+          If you're 100% positive that this migration is already safe, then
+          wrap the call to `add_column` in a `safety_assured` block.
+
+            class Add#{column_title}To#{table_title} < ActiveRecord::Migration
+              def change
+                safety_assured { add_column :#{table}, :#{column}, :#{column_type}, null: false }
+              end
+            end
+
         MESSAGE
       end
 

--- a/spec/zero_downtime_migrations/validation/add_column_spec.rb
+++ b/spec/zero_downtime_migrations/validation/add_column_spec.rb
@@ -56,4 +56,32 @@ RSpec.describe ZeroDowntimeMigrations::Validation::AddColumn do
       expect { migration.migrate(:up) }.not_to raise_error(error)
     end
   end
+
+  context "with a not nullable declaration" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          add_column :users, :active, :boolean, null: false
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+
+  context "with a nullable declaration" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          add_column :users, :active, :boolean, null: true
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.not_to raise_error(error)
+    end
+  end
 end


### PR DESCRIPTION
### What has been done
I've added checks to the `AddColumn` validator to make sure the migration doesn't add a column which is not null as this can cause outages on large tables.
