### PR TITLE
[PERF-219] Update zero downtime gem to check for `remove_column`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zero_downtime_migrations (0.0.7)
+    zero_downtime_migrations (0.0.8)
       activerecord
 
 GEM
@@ -106,4 +106,4 @@ DEPENDENCIES
   zero_downtime_migrations!
 
 BUNDLED WITH
-   1.16.0
+   2.0.1

--- a/lib/zero_downtime_migrations.rb
+++ b/lib/zero_downtime_migrations.rb
@@ -12,6 +12,8 @@ require_relative "zero_downtime_migrations/validation/ddl_migration"
 require_relative "zero_downtime_migrations/validation/drop_table"
 require_relative "zero_downtime_migrations/validation/find_each"
 require_relative "zero_downtime_migrations/validation/mixed_migration"
+require_relative "zero_downtime_migrations/validation/remove_column"
+require_relative "zero_downtime_migrations/validation/rename_column"
 
 ActiveRecord::Migration.send(:prepend, ZeroDowntimeMigrations::Migration)
 ActiveRecord::Schema.send(:prepend, ZeroDowntimeMigrations::Migration)

--- a/lib/zero_downtime_migrations/validation/remove_column.rb
+++ b/lib/zero_downtime_migrations/validation/remove_column.rb
@@ -1,0 +1,74 @@
+module ZeroDowntimeMigrations
+  class Validation
+    class RemoveColumn < Validation
+      def validate!
+        error!(remove_column_warning_message)
+      end
+
+      private
+
+      def remove_column_warning_message
+        <<-MESSAGE.strip_heredoc
+          Removing a column while a deployed and running version of the app
+          depends on that column is unsafe!
+
+          This can cause a signifant number of possibly critical errors while
+          the older version of the app is running and expecting the column to be
+          there.
+
+          First, deploy a version of the app which ignores the column. Note that
+          Rails 5.0 introduces an `ignored_columns` feature, however for previous
+          version of Rails you can use the `ignorable` gem to tell rails to
+          ignore one or more columns. However, be aware that any queries which
+          execute a `select * from table` could potentially still cause errors on
+          Rails 4 relating to cached prepared statements. To mitigate this issue the
+          following patch should be applied:
+
+          https://github.com/rails/rails/issues/12330#issuecomment-244930976
+
+          Example of ignoring a column using `ignorable` gem:
+
+            class #{table_model} < ActiveRecord::Base
+              ignore_columns #{column}
+            end
+
+          Then, deploy a version of the app which includes a migration to drop
+          the column and removes the code to ignore the column.
+
+          If you're 100% positive that this migration is already safe, then wrap
+          the call to `remove_column` in a `safety_assured` block.
+
+            class Remove#{column_title}From#{table_title} < ActiveRecord::Migration
+              def change
+                safety_assured { remove_column :#{table}, :#{column} }
+              end
+            end
+
+          Note: When removing an attribute from a model which is serialized in
+          API responses, be sure to consider how clients will handle responses
+          without the attribute.
+        MESSAGE
+      end
+
+      def column
+        args[1]
+      end
+
+      def column_title
+        column.to_s.camelize
+      end
+
+      def table
+        args[0]
+      end
+
+      def table_model
+        table_title.singularize
+      end
+
+      def table_title
+        table.to_s.camelize
+      end
+    end
+  end
+end

--- a/lib/zero_downtime_migrations/validation/rename_column.rb
+++ b/lib/zero_downtime_migrations/validation/rename_column.rb
@@ -1,0 +1,88 @@
+module ZeroDowntimeMigrations
+  class Validation
+    class RenameColumn < Validation
+      def validate!
+        error!(rename_column_warning_message)
+      end
+
+      private
+
+      def rename_column_warning_message
+        <<-MESSAGE.strip_heredoc
+          Renaming a column while a deployed and running version of the app
+          depends on that column is unsafe!
+
+          This can cause a signifant number of possibly critical errors while
+          the older version of the app is running and expecting the column to have
+          the original name.
+
+          Three separate releases are required.
+
+          First, add a new column and make sure the app is writing to it. Ensure
+          that the accessor reads from both columns, e.g.
+
+            class Add#{new_column_title}To#{table_title} < ActiveRecord::Migration
+              def change
+                add_column :#{table}, :#{new_column}, <data type and other options here>
+              end
+            end
+
+            class #{table_model} < ActiveRecord::Base
+              def #{new_column}
+                super || attributes["#{old_column}"]
+              end
+            end
+
+          Then, populate the new column with data from the previous one. The
+          second release includes updates to queries to refer to the new column
+          name.
+
+          Finally, in a third release, remove the old column.
+
+            class Remove#{old_column_title}From#{table_title} < ActiveRecord::Migration
+              def change
+                safety_assured { remove_column :#{table}, :#{old_column} }
+              end
+            end
+
+          If you're 100% positive that this migration is already safe, then wrap
+          the call to `rename_column` in a `safety_assured` block.
+
+            class Rename#{old_column_title}To#{new_column_title}On#{table_title} < ActiveRecord::Migration
+              def change
+                safety_assured { rename_column :#{table}, :#{old_column}, :#{new_column} }
+              end
+            end
+        MESSAGE
+      end
+
+      def old_column
+        args[1]
+      end
+
+      def new_column
+        args[2]
+      end
+
+      def old_column_title
+        old_column.to_s.camelize
+      end
+
+      def new_column_title
+        new_column.to_s.camelize
+      end
+
+      def table
+        args[0]
+      end
+
+      def table_model
+        table_title.singularize
+      end
+
+      def table_title
+        table.to_s.camelize
+      end
+    end
+  end
+end

--- a/spec/zero_downtime_migrations/validation/remove_column_spec.rb
+++ b/spec/zero_downtime_migrations/validation/remove_column_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ZeroDowntimeMigrations::Validation::RemoveColumn do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  context "when remove_column is called without safety_assured block" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          remove_column :users, :active
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+end

--- a/spec/zero_downtime_migrations/validation/rename_column_spec.rb
+++ b/spec/zero_downtime_migrations/validation/rename_column_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ZeroDowntimeMigrations::Validation::RenameColumn do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  context "when rename_column is called without safety_assured block" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          rename_column :users, :fname, :first_name
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+end

--- a/zero_downtime_migrations.gemspec
+++ b/zero_downtime_migrations.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
   s.summary               = "Zero downtime migrations with ActiveRecord and PostgreSQL"
   s.test_files            = `git ls-files -- spec/*`.split("\n")
-  s.version               = "0.0.8"
+  s.version               = "0.0.9"
 
   s.add_dependency "activerecord"
 end


### PR DESCRIPTION
## Ticket
https://airtasker.atlassian.net/browse/PERF-219

## Description & Context
Adds checks on `remove_column` and `rename_column` to force use of `safety_assured` and output advice on how best to manage the removal or renaming of columns.
